### PR TITLE
Add contact info sidebar to team page template

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,6 +69,8 @@ defaults:
   values:
     layout: team
     teamtag: 
+    team-email: 
+    team-slack: 
 subtitle: Home of the Berkeley Resistance.
 email: info@indivisibleberkeley.org
 baseurl: 

--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -2,6 +2,10 @@
 layout: default
 ---
 
+{% assign email-domain = "@indivisibleberkeley.org" %}
+{% assign email-subscribe = (page.team-email | append: "+subscribe" | append: email-domain) %}
+{% assign email-owner = (page.team-email | append: "+owner" | append: email-domain) %}
+{% assign email-list = (page.team-email | append: email-domain) %}
   <div class="container">
 
     <div class="clearfix spacer"></div>
@@ -12,6 +16,48 @@ layout: default
 
     <!-- BODY CONTENT -->
     <div class="row">
+      <!-- TEAM CONTACT INFO -->
+      <div class="col-sm-5 col-md-4 col-lg-3">
+        <div class="card">
+          <div class="card-header bg-medium">
+            <strong>Team info</strong>
+          </div>
+          <ul class="list-group list-group-flush">
+            {% if page.team-email %}
+              <li class="list-group-item">
+              <small>SUBSCRIBE</small>
+              <br>
+              <a href="mailto:{{ email-subscribe }}">{{ page.team-email }}+subscribe
+                  <br><small>{{ email-domain }}</small></a>
+              </li>
+              <li class="list-group-item">
+              <small>TEAM LEADS</small>
+              <br>
+              <a href="mailto:{{ email-owner }}">{{ page.team-email }}+owner
+                  <br><small>{{ email-domain }}</small></a>
+              </li>
+              <li class="list-group-item">
+              <small>EMAIL LIST</small>
+              <br>
+              <a href="mailto:{{ email-list }}">{{ page.team-email }}
+                  <br><small>{{ email-domain }}</small></a>
+              </li>
+            {% else %}
+              <li class="list-group-item">
+                  This team hasn't uploaded its email contact info yet. Check
+                  out our <a href="/teams">teams page</a> instead.
+              </li>
+            {% endif %}
+            {% if page.team-slack %}
+              <li class="list-group-item">
+              <small>SLACK</small><br>#{{ page.team-slack }}
+              </li>
+            {% endif %}
+          </ul>
+        </div>
+        <div class="clearfix spacer"></div>
+
+      </div>
       <div class="col-sm-8">
         
         <div class="post-list"> <!-- ACTIVE EVENTS -->

--- a/_teams/elections.markdown
+++ b/_teams/elections.markdown
@@ -2,6 +2,8 @@
 title: Elections
 date: 2017-08-17 21:15:00 -07:00
 teamtag: elections
+team-email: elections
+team-slack: elections
 ---
 
 The Elections Team focuses on flipping red districts through voter contact. We canvass, phonebank, write postcards, and register new voters. We work with and support local partners.

--- a/_teams/environment.markdown
+++ b/_teams/environment.markdown
@@ -2,6 +2,8 @@
 title: Science & Environment
 date: 2017-08-02 20:43:00 -07:00
 teamtag: environment
+team-email: environment
+team-slack: science_environment
 layout: team
 ---
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -543,3 +543,10 @@ td {
 .itemdate {
     margin-bottom: -0.7rem;
 }
+
+// IB: SIDEBAR/CARD SMALL LABEL ALIGNMENT
+
+.list-group-item {
+    flex-flow: column wrap;
+    align-items: left;
+}


### PR DESCRIPTION
This had a few side effects:

1. I added metadata fields in the _config.yml file (team-email and
team-slack).

2. I edited the metadata for the elections and environment teams.

3. I edited the SCSS rule for list items in the sidebar because the
default format only works in the specific situation it was created for
(office name labels for MoC phone numbers). The tweak to main.scss means
it works in general.

4. Of course, I had to edit the _layouts/team.html file.