### PR TITLE
Add new layout called allteams for the /teams page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -103,3 +103,4 @@ google_analytics: |-
 
   </script>
 permalink: "/:categories/:title"
+emptyArray: []

--- a/_includes/action-post-header.html
+++ b/_includes/action-post-header.html
@@ -15,17 +15,41 @@
         <!-- EVENT END DATE INFO -->
         {% if post.event-end-date %}
             <p class="mb-1 mt-1">by {{ post.event-end-date | date: "%b" }}</p>
-            <h3 class="itemdate"><strong>{{ post.event-end-date | date: "%-d" }}</strong></h3>
+            {% if short-post %}
+            <h4 class="itemdate">
+            {% else %}
+            <h3 class="itemdate">
+            {% endif %}
+                <strong>{{ post.event-end-date | date: "%-d" }}</strong>
+            {% if short-post %}
+            </h4>
+            {% else %}
+            </h3>
+            {% endif %}
         {% endif %}
             
             
         </center>
       </div>
       <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
+        {% if short-post %}
+        <h5 class="d-inline-block mb-2 mt-1 mt-sm-0">
+        {% else %}
         <h3 class="d-inline-block mb-2 mt-1 mt-sm-0">
+        {% endif %}
           <a class="post-link text-danger" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+        {% if short-post %}
+        </h5>
+        {% else %}
         </h3>
-        <div class="text-muted post-body">{{ post.content | strip_html | truncate: 140 }}</div>
+        {% endif %}
+        <div class="text-muted post-body">
+            {% if short-post %}
+            {{ post.content | strip_html | truncate: 70 }}
+            {% else %}
+            {{ post.content | strip_html | truncate: 140 }}
+            {% endif %}
+        </div>
       </div>
       <!-- POST MAIN IMAGE FIELD -->
       {% if post.main-image %}

--- a/_includes/event-post-header.html
+++ b/_includes/event-post-header.html
@@ -8,22 +8,49 @@
           <center>
             <span class="badge badge-primary">Event</span>
             <p class="mb-1 mt-1">{{ post.event-start-date | date: "%b" }}</p>
-            <h3 class="itemdate"><strong>{{ post.event-start-date | date: "%-d" }}</strong></h3>
+            {% if short-post %}
+            <h4 class="itemdate">
+            {% else %}
+            <h3 class="itemdate">
+            {% endif %}
+                <strong>{{ post.event-start-date | date: "%-d" }}</strong>
+            {% if short-post %}
+            </h4>
+            {% else %}
+            </h3>
+            {% endif %}
           </center>
         </div>
         {% endif %}
         <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
+          {% if short-post %}
+          <h5 class="mt-0 mb-1">
+          {% else %}
           <h3 class="mt-0 mb-1">
+          {% endif %}
             <a class="post-link"  href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+          {% if short-post %}
+          </h5>
+          {% else %}
           </h3>
+          {% endif %}
           <div class="row">
             {% if post.event-start-date %}
+            {% if short-post %}
+            <div class="col-12 text-muted">
+            {% else %}
             <div class="col-12 col-sm-3 text-muted">
+            {% endif %}
              <p class="mb-0">{{ post.event-start-date | date: "%l:%M %p" }} {% if post.event-end-date %}-{% endif %} {{ post.event-end-date | date: "%l:%M %p" }}</p>
             </div>
             {% endif %}
+            {% if short-post %}
+            <div class="col-12 text-muted">
+              <p>{{ post.Location | escape | truncate: 35 }}</p>
+            {% else %}
             <div class="col-7 col-sm-9 text-muted">
               <p>{{ post.Location | escape }}</p>
+            {% endif %}
             </div>
           </div>
         </div>

--- a/_layouts/allteams.html
+++ b/_layouts/allteams.html
@@ -1,0 +1,114 @@
+---
+layout: default
+---
+
+<article class="post">
+  <div class="container">
+
+    <header class="post-header">
+      <h1 class="post-title">{{ page.title | escape }}</h1>
+    </header>
+
+    <!-- Show 2 posts for each team -->
+    <div class="row">
+      {% assign sorted_teams = (site.teams | sort: "position") %}
+      {% for team in sorted_teams %}
+        <div class="col-12 col-md-6 col-lg-4">
+
+          <h3>
+              <a class="team-title" href="{{ team.url | absolute_url }}">{{ team.title }}</a>
+          </h3>
+          {% assign isfeature = "post['is featured'] == true" %}
+          {% assign isteam  = "post.tags contains team.teamtag" %}
+          {% assign isevent  = "post.categories contains 'event'" %}
+          {% assign isaction  = "post.categories contains 'action'" %}
+          {% capture event %} {{ isteam }} and {{ isevent }} {% endcapture %}
+          {% capture action %} {{ isteam }} and {{ isaction }} {% endcapture %}
+
+          {% assign teamposts = (site.posts|where_exp:"post",isteam) %}
+          {% assign unsorted_events = (teamposts|where_exp:"post",isevent) %}
+          {% assign unsorted_actions = (teamposts|where_exp:"post",isaction) %}
+
+          {% assign all_sorted_events = unsorted_events sort: "event-start-date" %}
+          {% assign all_sorted_actions = unsorted_actions sort: "event-end-date" %}
+
+          {% comment %} note events and actions lists are limited to
+          the max number of posts per team {% endcomment %}
+          {% assign curDate = site.time | date: '%s' %}
+          {% assign events = site.emptyArray %}
+          {% for event in all_sorted_events %}
+            {% assign eventDate = event.event-start-date | date: '%s' %}
+            {% if eventDate >= curDate %}
+              {% assign events = events | push: event %}
+              {% if events.size >= 2 %}
+                {% break %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+
+          {% assign actions = site.emptyArray %}
+          {% for action in all_sorted_actions %}
+            {% assign actionDate = action.event-end-date | date: '%s' %}
+            {% if actionDate >= curDate %}
+              {% assign actions = actions | push: action %}
+              {% if actions.size >= 2 %}
+                {% break %}
+              {% endif %}
+            {% endif %}
+          {% endfor %}
+
+          {% if events.size >= 1 and actions.size >= 1 %}
+            {% assign numposts = 2 %}
+            {% assign post1 = events[0] %}
+            {% assign post2 = actions[0] %}
+          {% elsif events.size >= 2 %}
+            {% assign numposts = 2 %}
+            {% assign post1 = events[0] %}
+            {% assign post2 = events[1] %}
+          {% elsif actions.size >= 2 %}
+            {% assign numposts = 2 %}
+            {% assign post1 = actions[0] %}
+            {% assign post2 = actions[1] %}
+          {% else %}
+            {% if events.size == 1 %}
+              {% assign numposts = 1 %}
+              {% assign post1 = events[0] %}
+            {% elsif actions.size == 1 %}
+              {% assign numposts = 1 %}
+              {% assign post1 = actions[0] %}
+            {% else %}
+              {% assign numposts = 0 %}
+            {% endif %}
+          {% endif %}
+
+          <!-- Blog Posts -->
+          <div class="post-list">
+            {% assign short-post = 1 %}
+            {% if numposts > 0 %}
+              {% assign post = post1 %}
+              {% include post-list.html %}
+            {% else %}
+              <span class="text-muted">
+              Check #{{ team.team-slack }} on Slack or email
+              {{ team.team-email }}+owner<wbr>@indivisibleberkeley.org to learn
+              about this team's upcoming actions and events!
+              </span>
+            {% endif %}
+            {% if numposts > 1 %}
+              {% assign post = post2 %}
+              {% include post-list.html %}
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <hr>
+
+    <div class="row post-content">
+      <div class="col col-sm-8">
+        {{ content }}
+      </div>
+    </div>
+
+  </div>
+</article>

--- a/_teams/big-ideas.markdown
+++ b/_teams/big-ideas.markdown
@@ -3,6 +3,8 @@ title: Big Ideas
 date: 2017-08-07 12:23:00 -07:00
 position: 4
 teamtag: bigideas
+team-email: bigideas
+team-slack: bigideas
 ---
 
 ### Our Team

--- a/_teams/elections.markdown
+++ b/_teams/elections.markdown
@@ -1,7 +1,7 @@
 ---
 title: Elections
 date: 2017-08-17 21:15:00 -07:00
-position: 5
+position: 0
 teamtag: elections
 team-email: elections
 team-slack: elections

--- a/_teams/environment.markdown
+++ b/_teams/environment.markdown
@@ -1,7 +1,7 @@
 ---
 title: Science & Environment
 date: 2017-08-02 20:43:00 -07:00
-position: 0
+position: 3
 teamtag: environment
 team-email: environment
 team-slack: science_environment

--- a/_teams/first-amendment.markdown
+++ b/_teams/first-amendment.markdown
@@ -1,8 +1,10 @@
 ---
 title: First Amendment
 date: 2017-08-07 12:02:00 -07:00
-position: 2
+position: 5
 teamtag: firstamendment
+team-email: firstamendment
+team-slack: firstamendment
 layout: team
 ---
 

--- a/_teams/immigration.markdown
+++ b/_teams/immigration.markdown
@@ -1,7 +1,7 @@
 ---
 title: Immigration
 date: 2017-08-07 12:06:00 -07:00
-position: 3
+position: 1
 teamtag: immigration
 team-email: immigration
 team-slack: immigration

--- a/_teams/rcjr.markdown
+++ b/_teams/rcjr.markdown
@@ -1,7 +1,7 @@
 ---
 title: Racism and Criminal Justice Reform
 date: 2017-09-04 19:35:00 -07:00
-position: 1
+position: 2
 teamtag: rcjr
 team-email: rcjr
 team-slack: racism_justice

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -550,3 +550,9 @@ td {
     flex-flow: column wrap;
     align-items: left;
 }
+
+// IB: TEAM TITLE HYPERLINK COLOR
+
+.team-title {
+    color: $text-color;
+}

--- a/teams.markdown
+++ b/teams.markdown
@@ -4,7 +4,7 @@ date: 2017-08-01 18:15:00 -07:00
 position: 0
 nav: true
 main-image: 
-layout: page
+layout: allteams
 ---
 
 Indivisible Berkeley teams are semi-autonomous groups organized around specific issues such as healthcare, elections, or criminal justice reform. Team members plan events and actions which are open to the entire Indivisible Berkeley community. Any community member is welcome to attend a team event or action. All of the team's contact information is on the corresponding team page. (Note: not all teams have their own page yet. Our volunteers are busy but we're working on it!) To join a team, do one of these three things:


### PR DESCRIPTION
The allteams layout displays a dashboard of up to 2 upcoming events/actions per team. The "teams" page.content is displayed below the dashboard.

This required the update of many files:

+ Obviously, the creation of _layouts/allteams.html, and the updating of teams.markdown to use `layout: allteams`

+ Editing action-post-header and event-post-header to make more compact posts (for the dashboard only, using the indicator variable `short-post`)

+ All of the _teams/* files, to add `position` attributes which dictate the order they are displayed on the dashboard

+ The Big Ideas and First Amendment team files, to add team-slack and team-email attributes so they will display correctly on the dashboard

+ assets/main.scss, to add an extra CSS rule to keep the team names from turning blue when they are hyperlinked