### PR TITLE
Fix bugs related to allteams layout (Teams page)

### DIFF
--- a/_includes/action-post-header.html
+++ b/_includes/action-post-header.html
@@ -31,12 +31,13 @@
             
         </center>
       </div>
-      <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
-        {% if short-post %}
+      {% if short-post %}
+      <div class="col-10 col-sm-9 col-lg-10">
         <h5 class="d-inline-block mb-2 mt-1 mt-sm-0">
-        {% else %}
+      {% else %}
+      <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
         <h3 class="d-inline-block mb-2 mt-1 mt-sm-0">
-        {% endif %}
+      {% endif %}
           <a class="post-link text-danger" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
         {% if short-post %}
         </h5>

--- a/_includes/event-post-header.html
+++ b/_includes/event-post-header.html
@@ -22,12 +22,13 @@
           </center>
         </div>
         {% endif %}
-        <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
-          {% if short-post %}
+        {% if short-post %}
+        <div class="col-10 col-sm-9 col-lg-10">
           <h5 class="mt-0 mb-1">
-          {% else %}
+        {% else %}
+        <div class="col-10 {% if post.main-image %}col-sm-6 col-lg-8{% else %}col-sm-9 col-lg-10{% endif %}">
           <h3 class="mt-0 mb-1">
-          {% endif %}
+        {% endif %}
             <a class="post-link"  href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
           {% if short-post %}
           </h5>

--- a/_layouts/allteams.html
+++ b/_layouts/allteams.html
@@ -11,7 +11,11 @@ layout: default
 
     <!-- Show 2 posts for each team -->
     <div class="row">
-      {% assign sorted_teams = (site.teams | sort: "position") %}
+      {% comment %} sort: "position", "last" means teams with no
+      position set will go at the end of the list. Positions can easily
+      be changed by dragging-and-dropping the team names in the siteleaf
+      interface. {% endcomment %}
+      {% assign sorted_teams = (site.teams | sort: "position", "last") %}
       {% for team in sorted_teams %}
         <div class="col-12 col-md-6 col-lg-4">
 
@@ -29,8 +33,8 @@ layout: default
           {% assign unsorted_events = (teamposts|where_exp:"post",isevent) %}
           {% assign unsorted_actions = (teamposts|where_exp:"post",isaction) %}
 
-          {% assign all_sorted_events = unsorted_events sort: "event-start-date" %}
-          {% assign all_sorted_actions = unsorted_actions sort: "event-end-date" %}
+          {% assign all_sorted_events = (unsorted_events|sort:"event-start-date","last") %}
+          {% assign all_sorted_actions = (unsorted_actions|sort:"event-end-date","last") %}
 
           {% comment %} note events and actions lists are limited to
           the max number of posts per team {% endcomment %}


### PR DESCRIPTION
+ Sort teams with no "position" property to the end of the list. (By default they
would go to the front.)

+ Fix bug in event/action sorting on allteams whereby the sorting
wouldn't happen because there was a syntax error.

+ Fix short-list alignment relating to missing photos. In short-list
mode, photos are not displayed, but they are still given space. this fix
removes that empty space.