### PR TITLE
Sort posts on homepage, only show active posts, + small tweak to actions page

### DIFF
--- a/_includes/sort-by-date.html
+++ b/_includes/sort-by-date.html
@@ -1,0 +1,67 @@
+{% comment %}
+This snippet will take the variable "posts_to_sort" and sort it by
+start-date for events and end-date for actions. Any updates will appear
+at the beginning.
+
+All the variables in this snippet begin with S_.
+
+The return variable is S_posts, the array of sorted posts.
+{% endcomment %}
+
+{% assign S_isevent  = "post.categories contains 'event'" %}
+{% assign S_isaction  = "post.categories contains 'action'" %}
+{% assign S_isupdate = "post.categories contains 'update'" %}
+
+{% assign S_unsorted_events = (posts_to_sort|where_exp:"post",S_isevent) %}
+{% assign S_unsorted_actions = (posts_to_sort|where_exp:"post",S_isaction) %}
+{% assign S_updates = (posts_to_sort|where_exp:"post",S_isupdate) %}
+
+{% assign S_events = (S_unsorted_events|sort:"event-start-date","last") %}
+{% assign S_actions = (S_unsorted_actions|sort:"event-end-date","last") %}
+
+{% assign S_ev_dates = (S_events | map: "event-start-date") %}
+{% assign S_act_dates = (S_actions | map: "event-end-date") %}
+
+
+{% assign S_event_index = 0 %}
+{% assign S_action_index = 0 %}
+
+{% assign S_posts = site.emptyArray %}
+
+{% for S_update in S_updates %}
+  {% assign S_posts = S_posts | push: S_update %}
+{% endfor %}
+
+{% assign S_used_events = site.emptyArray %}
+{% assign S_used_actions = site.emptyArray %}
+{% for S_i in S_events %}
+  {% assign S_next_ev_date = (S_ev_dates[S_event_index] | date: '%s') %}
+  {% assign S_next_act_date = (S_act_dates[S_action_index] | date: '%s') %}
+  {% if S_next_ev_date < S_next_act_date %}
+    {% assign S_next_event = S_events[S_event_index] %}
+    {% assign S_posts = (S_posts | push: S_next_event) %}
+    {% assign S_used_events = (S_used_events | push: S_next_event) %}
+    {% assign S_event_index = S_used_events | size %}
+  {% else %}
+    {% assign S_next_action = S_actions[S_action_index] %}
+    {% assign S_posts = (S_posts | push: S_next_action) %}
+    {% assign S_used_actions = (S_used_actions | push: S_next_action) %}
+    {% assign S_action_index = (S_used_actions | size) %}
+  {% endif %}
+{% endfor %}
+
+{% for S_i in S_actions %}
+  {% assign S_next_ev_date = (S_ev_dates[S_event_index] | date: '%s') %}
+  {% assign S_next_act_date = (S_act_dates[S_action_index] | date: '%s') %}
+  {% if S_next_ev_date < S_next_act_date %}
+    {% assign S_next_event = S_events[S_event_index] %}
+    {% assign S_posts = (S_posts | push: S_next_event) %}
+    {% assign S_used_events = (S_used_events | push: S_next_event) %}
+    {% assign S_event_index = S_used_events | size %}
+  {% else %}
+    {% assign S_next_action = S_actions[S_action_index] %}
+    {% assign S_posts = (S_posts | push: S_next_action) %}
+    {% assign S_used_actions = (S_used_actions | push: S_next_action) %}
+    {% assign S_action_index = (S_used_actions | size) %}
+  {% endif %}
+{% endfor %}

--- a/_layouts/actions.html
+++ b/_layouts/actions.html
@@ -81,10 +81,11 @@ layout: default
 
 
           <div class="col-sm-4">
-            <h5 class="mb-2">Suggest an Action</h5>
+            <h5 class="mb-2">Launch your action</h5>
             <hr class="mt-2 mb-2">
-            <p>Have an idea for an action? Want {{ site.title }} to promote it?</p>
-            <p><a class="btn btn-outline-primary" href="mailto:{{ site.email }}">Contact us</a></p>
+            <p>Have an idea for an action? You are the one you've been
+            waiting for, and we can help!</p>
+            <p><a class="btn btn-outline-primary" href="/teams">Join a team</a></p>
           </div>
 
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -48,12 +48,26 @@ layout: default
           {% assign featured_posts = (site.posts|where_exp:"post","post['is featured'] == true") %}
           {% assign not_featured_posts = (site.posts|where_exp:"post","post['is featured'] == false") %}
 
+          {% assign posts_to_sort = featured_posts %}
+          {% include sort-by-date.html %}
+          {% assign featured_posts = S_posts %}
+
+          {% assign curDate = site.time | date: '%s' %}
           {% for post in featured_posts %}
+            {% if post.categories contains 'event' %}
+              {% assign postEndDate = post.event-start-date | date: '%s' %}
+            {% elsif post.categories contains 'action' %}
+              {% assign postEndDate = post.event-end-date | date: '%s' %}
+            {% elsif post.categories contains 'update' %}
+              {% assign postEndDate = post.event-end-date | date: '%s' %}
+            {% endif %}
+            {% if postEndDate >= curDate %}
             <hr class="mt-0 mb-2">
           <!-- BADGE FOR FEATURED POSTS -->
 <!--             <span class="badge {% if post.categories contains 'action' %}badge-danger{% else %}badge-primary{% endif %}">PINNED</span> -->
             <!-- POST TEMPLATE -->
             {% include post-list.html %}
+            {% endif %}
           {% endfor %}
 
         </div><!-- END BLOG POSTS -->


### PR DESCRIPTION
I created an _includes file which takes an array of actions, updates and events and sorts them so that the updates are first, and then the actions and events are sorted by date (start date for events, end date for actions).

Then I used this `sort-by-date` _includes file on the homepage to sort the featured events by date. To make this work, I also upgraded the filter to remove posts which have expired. Events expire at their start date, and actions and updates expire at their end date.

Lastly, I reworded the sidebar on the /actions page to make it clear that we want folks to join our teams to take action.