### PR TITLE
Update the heading of the featured posts list on the homepage

### DIFF
--- a/_layouts/allteams.html
+++ b/_layouts/allteams.html
@@ -8,6 +8,12 @@ layout: default
     <header class="post-header">
       <h1 class="post-title">{{ page.title | escape }}</h1>
     </header>
+    <div class="row">
+        <div class="col-12">
+            <p>Click on a team name to see all of their events and
+            actions!</p>
+        </div>
+    </div>
 
     <!-- Show 2 posts for each team -->
     <div class="row">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,9 +40,20 @@ layout: default
     <div class="row">
 
       <div class="col-sm-8">
+          <div class="row mt-4">
+              <div class="col-12 col-md-4">
+                  <a href="/actions" class="btn btn-block btn-danger">All current actions</a></br>
+              </div>
+              <div class="col-12 col-md-4">
+                  <a href="/calendar" class="btn btn-block btn-primary">All upcoming events</a></br>
+              </div>
+              <div class="col-12 col-md-4">
+                  <a href="/archive" class="btn btn-block btn-secondary">Archive</a>
+              </div>
+          </div>
 
         <!-- Blog Posts -->
-<!--         <h2>Featured Actions, Events, and News</h2> -->
+        <h3>Featured Actions, Events, and News</h3>
         <div class="post-list">
 
           {% assign featured_posts = (site.posts|where_exp:"post","post['is featured'] == true") %}
@@ -75,9 +86,6 @@ layout: default
         <!-- Pagination links -->
         <hr class="mt-2 mb-4">
         <div class="pagination">
-          <a href="/actions" class="next ml-auto">All current actions &rarr;</a></br>
-          <a href="/calendar" class="next ml-auto">All upcoming events &rarr;</a></br>
-          <a href="/archive" class="next ml-auto">Archive &rarr;</a>
         </div>
 
         <div class="spacer clearfix"></div>


### PR DESCRIPTION
I added buttons for "all actions," "all events," and "archive" to the top of the page. I also added a "featured posts" heading. These changes should make it more clear what's going on, and particularly that there are more actions than just what's on the home page.

I also added a short description to the /teams page explaining that you can click on a team name.